### PR TITLE
fix: remove smithery url from mcp-publish

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Decodo/decodo-mcp-server",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "0.1.0",
   "packages": [
     {
       "registryType": "npm",
@@ -33,12 +33,6 @@
           "isSecret": true
         }
       ]
-    }
-  ],
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://server.smithery.ai/@Decodo/decodo-mcp-server/mcp"
     }
   ]
 }


### PR DESCRIPTION
Removing smithery repote link (which throws a validation error) while the mcp-publish team considers removing validation:
https://github.com/modelcontextprotocol/registry/issues/494#issuecomment-3329422136