### PR TITLE
feat: add proxy IP whitelist management tools

### DIFF
--- a/src/clients/proxy-api-client.ts
+++ b/src/clients/proxy-api-client.ts
@@ -17,7 +17,7 @@ export class ProxyApiClient {
 
   private get headers() {
     return {
-      Authorization: `Token ${this.apiKey}`,
+      Authorization: this.apiKey,
       'Content-Type': 'application/json',
     };
   }
@@ -29,13 +29,12 @@ export class ProxyApiClient {
     return res.data;
   };
 
-  addWhitelistedIps = async (ips: string[]): Promise<WhitelistedIp[]> => {
-    const res = await axios.post<WhitelistedIp[]>(
+  addWhitelistedIps = async (ips: string[]): Promise<void> => {
+    await axios.post(
       `${this.baseUrl}/whitelisted-ips`,
       { IPAddressList: ips },
       { headers: this.headers }
     );
-    return res.data;
   };
 
   removeWhitelistedIp = async (id: number): Promise<void> => {

--- a/src/clients/proxy-api-client.ts
+++ b/src/clients/proxy-api-client.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+export type WhitelistedIp = {
+  id: number;
+  ip: string;
+  enabled: boolean;
+  created_at: string;
+};
+
+export class ProxyApiClient {
+  private apiKey: string;
+  private baseUrl = 'https://api.decodo.com/v2';
+
+  constructor({ apiKey }: { apiKey: string }) {
+    this.apiKey = apiKey;
+  }
+
+  private get headers() {
+    return {
+      Authorization: `Token ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  listWhitelistedIps = async (): Promise<WhitelistedIp[]> => {
+    const res = await axios.get<WhitelistedIp[]>(`${this.baseUrl}/whitelisted-ips`, {
+      headers: this.headers,
+    });
+    return res.data;
+  };
+
+  addWhitelistedIps = async (ips: string[]): Promise<WhitelistedIp[]> => {
+    const res = await axios.post<WhitelistedIp[]>(
+      `${this.baseUrl}/whitelisted-ips`,
+      { IPAddressList: ips },
+      { headers: this.headers }
+    );
+    return res.data;
+  };
+
+  removeWhitelistedIp = async (id: number): Promise<void> => {
+    await axios.delete(`${this.baseUrl}/whitelisted-ips/${id}`, {
+      headers: this.headers,
+    });
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@ if (process.env.ENABLE_MCPS_LOGGER) {
   import('mcps-logger/console');
 }
 
-const parseEnvsOrExit = (): Record<string, string> => {
-  const envs = ['SCRAPER_API_USERNAME', 'SCRAPER_API_PASSWORD'];
+const parseEnvsOrExit = (): { sapiUsername: string; sapiPassword: string; decodoApiKey?: string } => {
+  const requiredEnvs = ['SCRAPER_API_USERNAME', 'SCRAPER_API_PASSWORD'];
 
-  for (const envKey of envs) {
+  for (const envKey of requiredEnvs) {
     if (!process.env[envKey]) {
       exit(`env ${envKey} missing`);
     }
@@ -20,6 +20,7 @@ const parseEnvsOrExit = (): Record<string, string> => {
   return {
     sapiUsername: process.env['SCRAPER_API_USERNAME'] as string,
     sapiPassword: process.env['SCRAPER_API_PASSWORD'] as string,
+    decodoApiKey: process.env['DECODO_API_KEY'],
   };
 };
 
@@ -27,11 +28,12 @@ async function main() {
   const transport = new StdioServerTransport();
 
   // if there are no envs, some MCP clients will fail silently
-  const { sapiUsername, sapiPassword } = parseEnvsOrExit();
+  const { sapiUsername, sapiPassword, decodoApiKey } = parseEnvsOrExit();
 
   const sapiMcpServer = new ScraperAPIMCPServer({
     sapiUsername,
     sapiPassword,
+    decodoApiKey,
   });
   await sapiMcpServer.connect(transport);
 

--- a/src/sapi-mcp-server.ts
+++ b/src/sapi-mcp-server.ts
@@ -1,12 +1,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ScraperApiClient } from './clients/scraper-api-client';
+import { ProxyApiClient } from './clients/proxy-api-client';
 import {
   AmazonSearchParsedTool,
   GoogleSearchParsedTool,
   RedditPostTool,
   RedditSubredditTool,
   ScrapeAsMarkdownTool,
+  ListWhitelistedIpsTool,
+  AddWhitelistedIpsTool,
+  RemoveWhitelistedIpTool,
 } from './tools';
 
 export class ScraperAPIMCPServer {
@@ -14,7 +18,17 @@ export class ScraperAPIMCPServer {
 
   sapiClient: ScraperApiClient;
 
-  constructor({ sapiUsername, sapiPassword }: { sapiUsername: string; sapiPassword: string }) {
+  proxyClient: ProxyApiClient | null;
+
+  constructor({
+    sapiUsername,
+    sapiPassword,
+    decodoApiKey,
+  }: {
+    sapiUsername: string;
+    sapiPassword: string;
+    decodoApiKey?: string;
+  }) {
     this.server = new McpServer({
       name: 'decodo',
       version: '0.1.0',
@@ -28,6 +42,7 @@ export class ScraperAPIMCPServer {
     const auth = Buffer.from(`${sapiUsername}:${sapiPassword}`).toString('base64');
 
     this.sapiClient = new ScraperApiClient({ auth });
+    this.proxyClient = decodoApiKey ? new ProxyApiClient({ apiKey: decodoApiKey }) : null;
 
     this.registerTools();
     this.registerResources();
@@ -46,6 +61,13 @@ export class ScraperAPIMCPServer {
     AmazonSearchParsedTool.register({ server: this.server, sapiClient: this.sapiClient });
     RedditPostTool.register({ server: this.server, sapiClient: this.sapiClient });
     RedditSubredditTool.register({ server: this.server, sapiClient: this.sapiClient });
+
+    // proxy management (requires DECODO_API_KEY)
+    if (this.proxyClient) {
+      ListWhitelistedIpsTool.register({ server: this.server, proxyClient: this.proxyClient });
+      AddWhitelistedIpsTool.register({ server: this.server, proxyClient: this.proxyClient });
+      RemoveWhitelistedIpTool.register({ server: this.server, proxyClient: this.proxyClient });
+    }
   }
 
   registerResources() {

--- a/src/tools/add-whitelisted-ips-tool.ts
+++ b/src/tools/add-whitelisted-ips-tool.ts
@@ -14,15 +14,19 @@ export class AddWhitelistedIpsTool {
           .describe('List of IPv4 addresses to whitelist'),
       },
       async ({ ips }: { ips: string[] }) => {
-        const added = await proxyClient.addWhitelistedIps(ips);
+        await proxyClient.addWhitelistedIps(ips);
+        const allIps = await proxyClient.listWhitelistedIps();
 
-        const formatted = added
-          .map(ip => `- **${ip.ip}** (id: ${ip.id})`)
+        const formatted = allIps
+          .map(ip => `- **${ip.ip}** (id: ${ip.id}, enabled: ${ip.enabled})`)
           .join('\n');
 
         return {
           content: [
-            { type: 'text', text: `Successfully whitelisted ${added.length} IP(s):\n\n${formatted}` },
+            {
+              type: 'text',
+              text: `Successfully added ${ips.length} IP(s). Current whitelist (${allIps.length} total):\n\n${formatted}`,
+            },
           ],
         };
       }

--- a/src/tools/add-whitelisted-ips-tool.ts
+++ b/src/tools/add-whitelisted-ips-tool.ts
@@ -1,0 +1,31 @@
+import z from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ProxyApiClient } from '../clients/proxy-api-client';
+
+export class AddWhitelistedIpsTool {
+  static register = ({ server, proxyClient }: { server: McpServer; proxyClient: ProxyApiClient }) => {
+    server.tool(
+      'add_whitelisted_ips',
+      'Add one or more IP addresses to the proxy authentication whitelist on your Decodo account. IPv4 only.',
+      {
+        ips: z
+          .array(z.string().ip({ version: 'v4' }))
+          .min(1)
+          .describe('List of IPv4 addresses to whitelist'),
+      },
+      async ({ ips }: { ips: string[] }) => {
+        const added = await proxyClient.addWhitelistedIps(ips);
+
+        const formatted = added
+          .map(ip => `- **${ip.ip}** (id: ${ip.id})`)
+          .join('\n');
+
+        return {
+          content: [
+            { type: 'text', text: `Successfully whitelisted ${added.length} IP(s):\n\n${formatted}` },
+          ],
+        };
+      }
+    );
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,3 +3,6 @@ export * from './google-search-parsed-tool';
 export * from './reddit-subreddit-tool';
 export * from './reddit-post-tool';
 export * from './scrape-as-markdown-tool';
+export * from './list-whitelisted-ips-tool';
+export * from './add-whitelisted-ips-tool';
+export * from './remove-whitelisted-ip-tool';

--- a/src/tools/list-whitelisted-ips-tool.ts
+++ b/src/tools/list-whitelisted-ips-tool.ts
@@ -1,0 +1,31 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ProxyApiClient } from '../clients/proxy-api-client';
+
+export class ListWhitelistedIpsTool {
+  static register = ({ server, proxyClient }: { server: McpServer; proxyClient: ProxyApiClient }) => {
+    server.tool(
+      'list_whitelisted_ips',
+      'List all IP addresses whitelisted for proxy authentication on your Decodo account',
+      {},
+      async () => {
+        const ips = await proxyClient.listWhitelistedIps();
+
+        if (ips.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No whitelisted IPs found.' }],
+          };
+        }
+
+        const formatted = ips
+          .map(ip => `- **${ip.ip}** (id: ${ip.id}, enabled: ${ip.enabled}, added: ${ip.created_at})`)
+          .join('\n');
+
+        return {
+          content: [
+            { type: 'text', text: `Found ${ips.length} whitelisted IP(s):\n\n${formatted}` },
+          ],
+        };
+      }
+    );
+  };
+}

--- a/src/tools/remove-whitelisted-ip-tool.ts
+++ b/src/tools/remove-whitelisted-ip-tool.ts
@@ -1,0 +1,24 @@
+import z from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ProxyApiClient } from '../clients/proxy-api-client';
+
+export class RemoveWhitelistedIpTool {
+  static register = ({ server, proxyClient }: { server: McpServer; proxyClient: ProxyApiClient }) => {
+    server.tool(
+      'remove_whitelisted_ip',
+      'Remove a whitelisted IP address from your Decodo account by its ID. Use list_whitelisted_ips to find the ID.',
+      {
+        id: z.number().describe('The ID of the whitelisted IP entry to remove (from list_whitelisted_ips)'),
+      },
+      async ({ id }: { id: number }) => {
+        await proxyClient.removeWhitelistedIp(id);
+
+        return {
+          content: [
+            { type: 'text', text: `Successfully removed whitelisted IP entry with id: ${id}` },
+          ],
+        };
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary

Adds three new MCP tools for managing Decodo proxy IP whitelists via the v2 API (`api.decodo.com/v2`):

- **`list_whitelisted_ips`** — List all whitelisted IPs on the account
- **`add_whitelisted_ips`** — Add one or more IPv4 addresses to the whitelist
- **`remove_whitelisted_ip`** — Remove a whitelisted IP by its ID

These tools enable AI agents to programmatically manage proxy authentication whitelists without manual dashboard access — useful for automated server provisioning workflows.

## Implementation details

- New `ProxyApiClient` class for the Decodo v2 API (uses API key auth via `Authorization: Token <key>` header)
- Tools are **conditionally registered** only when `DECODO_API_KEY` env var is set, so existing scraping-only setups are unaffected
- Follows the existing tool class pattern (`static register()` method)
- IPv4 validation via Zod schema on the add tool

## Configuration

Users opt in by setting the `DECODO_API_KEY` environment variable (generated at dashboard.decodo.com > Account Settings > API Keys).

## Test plan

- [x] Existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing with a Decodo account and API key