### PR TITLE
Add Dockerfile for containerized MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/build ./build
+
+ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
## Summary

Adds a `Dockerfile` so the Decodo MCP server can be built and run as a container. This is required to list the server in the [Docker MCP Registry](https://github.com/docker/mcp-registry).

## Details

- Multi-stage build on `node:22-alpine`
- Builds the TypeScript sources with `npm run build`
- Runs the stdio entry point (`build/index.js`) as the container `ENTRYPOINT`

Verified locally: the image builds and lists all 30 tools over stdio.