### PR TITLE
Enable CORS for browser-based auth on MCP HTTP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.3",
         "axios": "^1.15.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.5.0",
+        "express": "^5.2.1",
         "node-html-markdown": "^1.3.0",
         "tsx": "^4.21.0"
       },
@@ -25,6 +27,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "@semantic-release/npm": "^13.1.5",
+        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.0",
@@ -5099,6 +5102,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.3",
     "axios": "^1.15.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.5.0",
+    "express": "^5.2.1",
     "node-html-markdown": "^1.3.0",
     "tsx": "^4.21.0"
   },
@@ -40,6 +42,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,14 @@
 import 'dotenv/config';
+import cors from 'cors';
 import express from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { corsOptions } from './server/cors';
 import { ScraperAPIHttpServer } from './server/sapi-http-server';
 import { resolveToolsets } from './utils';
 
 const app = express();
 
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.get('/mcp', (_req, res) => {

--- a/src/server/__tests__/cors.test.ts
+++ b/src/server/__tests__/cors.test.ts
@@ -1,0 +1,83 @@
+import cors from 'cors';
+import express from 'express';
+import { corsOptions, isAllowedOrigin } from '../cors';
+
+describe('CORS origin allowlist', () => {
+  it('allows requests with no origin', () => {
+    expect(isAllowedOrigin(undefined)).toBe(true);
+  });
+
+  it('allows claude.ai and subdomains', () => {
+    expect(isAllowedOrigin('https://claude.ai')).toBe(true);
+    expect(isAllowedOrigin('https://www.claude.ai')).toBe(true);
+  });
+
+  it('allows anthropic.com and subdomains', () => {
+    expect(isAllowedOrigin('https://anthropic.com')).toBe(true);
+    expect(isAllowedOrigin('https://api.anthropic.com')).toBe(true);
+  });
+
+  it('allows local development origins', () => {
+    expect(isAllowedOrigin('http://localhost:3000')).toBe(true);
+    expect(isAllowedOrigin('http://127.0.0.1:6274')).toBe(true);
+  });
+
+  it('rejects unknown origins', () => {
+    expect(isAllowedOrigin('https://evil.com')).toBe(false);
+    expect(isAllowedOrigin('https://claude.ai.evil.com')).toBe(false);
+  });
+});
+
+describe('CORS middleware behavior', () => {
+  const withTestServer = async (
+    run: (port: number) => Promise<void>
+  ): Promise<void> => {
+    const app = express();
+    app.use(cors(corsOptions));
+    app.get('/mcp', (_req, res) => {
+      res.status(200).send('ok');
+    });
+
+    const server = app.listen(0);
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await run(port);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  };
+
+  it('does not return 500 for disallowed origins', async () => {
+    await withTestServer(async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        headers: { Origin: 'https://evil.com' },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    });
+  });
+
+  it('returns CORS headers for allowed origins', async () => {
+    await withTestServer(async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        headers: { Origin: 'https://claude.ai' },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('access-control-allow-origin')).toBe(
+        'https://claude.ai'
+      );
+    });
+  });
+});

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,31 @@
+import cors from 'cors';
+
+const ALLOWED_ORIGIN_PATTERNS = [
+  /^https:\/\/([a-z0-9-]+\.)*claude\.ai$/,
+  /^https:\/\/([a-z0-9-]+\.)*anthropic\.com$/,
+  /^http:\/\/localhost(:\d+)?$/,
+  /^http:\/\/127\.0\.0\.1(:\d+)?$/,
+];
+
+export const isAllowedOrigin = (origin: string | undefined): boolean => {
+  if (!origin) {
+    return true;
+  }
+
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
+};
+
+export const corsOptions: cors.CorsOptions = {
+  origin: (origin, callback) => {
+    if (isAllowedOrigin(origin)) {
+      callback(null, true);
+      return;
+    }
+
+    callback(null, false);
+  },
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id'],
+  exposedHeaders: ['Mcp-Session-Id'],
+  maxAge: 86400,
+};

--- a/src/utils/__tests__/progress.test.ts
+++ b/src/utils/__tests__/progress.test.ts
@@ -87,7 +87,9 @@ describe('ProgressNotifier', () => {
         },
       });
 
-      if (timeout) clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       jest.useRealTimers();
     });
 


### PR DESCRIPTION
## Summary
- Add CORS middleware to the HTTP server so browser clients (e.g. Claude Connector) can preflight and send `Authorization` headers to `/mcp`.
- Allow `claude.ai`, `anthropic.com`, and local dev origins; deny unknown origins without returning 500.
- Add unit and integration tests for the origin allowlist and middleware behavior.

## Test plan
- [x] `npm test -- --testPathPattern=cors`
- [x] Start locally (`npm run build && node build/server.js`), then preflight: `curl -sI -X OPTIONS http://localhost:3000/mcp -H "Origin: https://claude.ai" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Authorization, Content-Type"` — expect `204` with `Access-Control-Allow-Origin` and `Authorization` in allowed headers
- [ ] After merge, deploy via GitLab mcp-server-deployer and confirm the same preflight against `https://mcp.decodo.com/mcp`