### PR TITLE
feat: add Smithery MCPB bundle with tools:[] workaround

### DIFF
--- a/smithery/README.md
+++ b/smithery/README.md
@@ -1,0 +1,24 @@
+# Smithery MCPB bundle
+
+Publishing to [Smithery](https://smithery.ai) requires either OAuth support or a
+`.mcpb` bundle under 25MB (see SCR-3048). This folder provides a minimal stdio
+bundle that launches the npm-published `@decodo/mcp-server`, keeping the bundle a
+few hundred bytes instead of embedding `node_modules`.
+
+## Workaround note
+
+Smithery currently rejects stdio bundles whose manifest omits `tools` with
+`400 {"error":"No values to set"}` ([smithery-ai/cli#770](https://github.com/smithery-ai/cli/issues/770)).
+The manifest here includes an explicit `"tools": []` so the release payload is
+accepted. Runtime tool discovery is unaffected.
+
+## Publish
+
+```bash
+# from the repo root
+npx @anthropic-ai/mcpb pack smithery decodo-mcp.mcpb
+npx smithery auth login            # if not already authenticated
+npx smithery mcp publish ./decodo-mcp.mcpb -n Decodo/mcp-server
+```
+
+Keep `version` in `manifest.json` in sync with `package.json` before publishing.

--- a/smithery/index.js
+++ b/smithery/index.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("child_process");
+
+const child = spawn("npx", ["-y", "@decodo/mcp-server"], {
+  stdio: "inherit",
+  env: process.env,
+  shell: process.platform === "win32",
+});
+
+child.on("exit", code => process.exit(code ?? 0));
+child.on("error", err => {
+  console.error("Failed to start @decodo/mcp-server:", err);
+  process.exit(1);
+});

--- a/smithery/manifest.json
+++ b/smithery/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": "0.3",
+  "name": "decodo-mcp-server",
+  "display_name": "Decodo MCP Server",
+  "version": "1.2.3",
+  "description": "Enable your AI agents to scrape and parse web content dynamically, including geo-restricted sites",
+  "author": {
+    "name": "Decodo"
+  },
+  "homepage": "https://github.com/Decodo/mcp-server#readme",
+  "documentation": "https://github.com/Decodo/mcp-server#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Decodo/mcp-server.git"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/index.js"],
+      "env": {
+        "SCRAPER_API_TOKEN": "${user_config.scraper_api_token}"
+      }
+    }
+  },
+  "user_config": {
+    "scraper_api_token": {
+      "type": "string",
+      "title": "Scraper API Token",
+      "description": "Authentication token for the Decodo Scraper API",
+      "required": true,
+      "sensitive": true
+    }
+  },
+  "tools": []
+}


### PR DESCRIPTION
## Summary

Unblocks publishing to Smithery.

Smithery now requires **either** OAuth support **or** a `.mcpb` bundle under 25MB. Our previous bundle was ~270MB (embedded `node_modules`). This adds a minimal **stdio** bundle that simply launches the npm-published `@decodo/mcp-server` via `npx`, so the packed bundle is <1KB.

## Why not OAuth?

The bundle path is the lighter alternative to implementing OAuth on the server. Since we already publish to npm, a thin launcher bundle is enough to get Smithery showing up-to-date capabilities.

## tools:[] workaround

Smithery currently rejects stdio bundles whose manifest omits `tools` with `400 {"error":"No values to set"}` — [smithery-ai/cli#770](https://github.com/smithery-ai/cli/issues/770) (still open upstream, community-verified workaround). The manifest includes an explicit `"tools": []` so the release payload is accepted. Runtime tool discovery is unaffected.

## Contents

- `smithery/manifest.json` — MCPB manifest (stdio, node launcher, `tools: []`)
- `smithery/index.js` — thin launcher that runs `npx -y @decodo/mcp-server`
- `smithery/README.md` — publish steps

## Verification

```
npx @anthropic-ai/mcpb validate smithery/manifest.json   # passes
npx @anthropic-ai/mcpb pack smithery decodo-mcp.mcpb     # ~917B, tools:[] survives round-trip
```

Publishing itself is a CLI step (not part of this PR):
```
npx @anthropic-ai/mcpb pack smithery decodo-mcp.mcpb
npx smithery mcp publish ./decodo-mcp.mcpb -n Decodo/mcp-server
```

## Note

- `SCRAPER_API_TOKEN` is used as the env var (matches current `build/index.js`); the old Smithery config used `sapiUsername`/`sapiPassword`. Please confirm this is correct.
- Keep `version` in `manifest.json` in sync with `package.json`.